### PR TITLE
Fix mpsHome detection logic to work with custom RCPs

### DIFF
--- a/mps-build-tools/src/main/kotlin/org/modelix/buildtools/ModulesMiner.kt
+++ b/mps-build-tools/src/main/kotlin/org/modelix/buildtools/ModulesMiner.kt
@@ -66,6 +66,10 @@ class ModulesMiner() {
                     }
                 }
                 "jar" -> {
+                    if (file.name == "mps-boot.jar" && file.parentFile.name == "lib") {
+                        modules.mpsHome = file.parentFile.parentFile
+                    }
+
                     if (file.name == "mps-workbench.jar" && file.parentFile.name == "lib") {
                         // This MPS plugin seems to use some old way of packaging a plugin
                         // The descriptor declares 'com.intellij' as the ID, but it's actually 'com.intellij.modules.mps'.
@@ -125,11 +129,6 @@ class ModulesMiner() {
 //                                }
 //                            }
 //                        }
-                    }
-                }
-                "vmoptions" -> {
-                    if (file.nameWithoutExtension == "mps" || file.nameWithoutExtension == "mps64") {
-                        modules.mpsHome = file.parentFile.parentFile
                     }
                 }
             }


### PR DESCRIPTION
The current logic is based on locating `mps(64).vmoptions` but this file will be named differently in custom RCPs. This PR changes it to look for `mps-boot.jar` instead.